### PR TITLE
Make PDF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 
 /.quarto/
 /_site/
+
+nul

--- a/_make_pdf.qmd
+++ b/_make_pdf.qmd
@@ -1,0 +1,140 @@
+---
+title: Best Practices for Data Visualisation
+subtitle: Insights, advice, and examples (with code) to make data outputs more readable, accessible, and impactful
+author: "Andreas Krause, Nicola Rennie, & Brian Tarran"
+format:
+  pdf:
+    toc: true
+    toc-depth: 2
+    number-sections: true
+    number-depth: 2
+    output-file: "RSS-data-vis-guide"
+    output-ext:  "pdf"
+editor: source
+---
+
+```{r}
+#| echo: false
+#| eval: true
+process_qmd <- function(file, fpath_in = "images/", fpath_out = "images/") {
+  doc <- readLines(file)
+  end_yaml <- which(doc == "---")[2]
+  out_doc <- doc[seq(end_yaml+1, length(doc))]
+  if (fpath_in != fpath_out) {
+    out_doc <- stringr::str_replace_all(out_doc, fpath_in, fpath_out)
+  }
+  res <- knitr::knit_child(text = out_doc, quiet = TRUE, options = list(eval = FALSE, echo = TRUE))
+  return(res)
+}
+```
+
+# Introduction
+
+```{r}
+#| output: asis
+#| echo: false
+#| eval: true
+#| message: false
+idx <- process_qmd("index.qmd")
+cat(unlist(idx), sep = '\n')
+```
+
+# How to use this guide
+
+```{r}
+#| output: asis
+#| echo: false
+#| eval: true
+#| message: false
+howto <- process_qmd("howto.qmd")
+cat(unlist(howto), sep = '\n')
+```
+
+# Why we visualise data
+
+```{r}
+#| output: asis
+#| echo: false
+#| eval: true
+#| message: false
+why <- process_qmd("docs/why-visualise.qmd", fpath_in = "images/", fpath_out = "docs/images/")
+cat(unlist(why), sep = '\n')
+```
+
+# Principles and elements of visualisations
+
+```{r}
+#| output: asis
+#| echo: false
+#| eval: true
+#| message: false
+principles <- process_qmd("docs/principles.qmd", fpath_in = "images/", fpath_out = "docs/images/")
+cat(unlist(principles), sep = '\n')
+```
+
+# Choosing a visualisation type
+
+```{r}
+#| output: asis
+#| echo: false
+#| eval: true
+#| message: false
+choosing <- process_qmd("docs/choosing.qmd", fpath_in = "images/", fpath_out = "docs/images/")
+cat(unlist(choosing), sep = '\n')
+```
+
+# Styling for accessibility
+
+```{r}
+#| output: asis
+#| echo: false
+#| eval: true
+#| message: false
+styling <- process_qmd("docs/styling.qmd", fpath_in = "images/", fpath_out = "docs/images/")
+cat(unlist(styling), sep = '\n')
+```
+
+
+# Styling for RSS Publications
+
+```{r}
+#| output: asis
+#| echo: false
+#| eval: true
+#| message: false
+tools <- process_qmd("docs/tools.qmd", fpath_in = "images/", fpath_out = "docs/images/")
+cat(unlist(tools), sep = '\n')
+```
+
+# References
+
+```{r}
+#| output: asis
+#| echo: false
+#| eval: true
+#| message: false
+refs <- process_qmd("docs/references.qmd")
+cat(unlist(refs), sep = '\n')
+```
+
+# About the authors
+
+```{r}
+#| output: asis
+#| echo: false
+#| eval: true
+#| message: false
+about <- process_qmd("about.qmd")
+cat(unlist(about), sep = '\n')
+```
+
+# Terms and Conditions
+
+```{r}
+#| output: asis
+#| echo: false
+#| eval: true
+#| message: false
+ts_and_cs <- process_qmd("ts-and-cs.qmd")
+cat(unlist(ts_and_cs), sep = '\n')
+```

--- a/about.qmd
+++ b/about.qmd
@@ -46,7 +46,7 @@ Nicola Rennie is an academic, data scientist, and educator with a passion for ef
 
 ::: grid
 ::: {.g-col-12 .g-col-md-6}
-Brian Tarran is a writer and editor with 20 years of experience covering the research and data space. Has has worked for the Royal Statistical Society (RSS) for the past 8 years, and was editor of [*Significance* Magazine](https://www.significancemagazine.com/) (a joint publication of the RSS, the American Statistical Association and the Statistical Society of Australia) prior to the launch of [Real World Data Science](https://realworlddatascience.net/). Brian is a former editor of Research-Live.com and was launch editor of Impact magazine, both published by the Market Research Society.
+Brian Tarran is a writer and editor with 20 years of experience covering the research and data space. He has worked for the Royal Statistical Society (RSS) for the past 8 years, and was editor of [*Significance* Magazine](https://www.significancemagazine.com/) (a joint publication of the RSS, the American Statistical Association and the Statistical Society of Australia) prior to the launch of [Real World Data Science](https://realworlddatascience.net/). Brian is a former editor of Research-Live.com and was launch editor of Impact magazine, both published by the Market Research Society.
 
 -   Twitter: [\@brtarran](https://twitter.com/brtarran)
 -   LinkedIn: [linkedin.com/in/brian-tarran-58b0261](https://www.linkedin.com/in/brian-tarran-58b0261/)

--- a/howto.qmd
+++ b/howto.qmd
@@ -3,7 +3,9 @@ title: How to use this guide
 toc: true
 ---
 
-We designed this guide to be read from beginning to end, so that each section builds on the foundations of those that came before. If this is your first time reading the guide, we would encourage you to read it in this way. However, those looking for guidance on specific aspects of data visualisation can make use of the search and navigation functions of this website. If you would prefer to read offline, you can download PDFs of the individual pages that make up this guide.
+We designed this guide to be read from beginning to end, so that each section builds on the foundations of those that came before. If this is your first time reading the guide, we would encourage you to read it in this way. However, those looking for guidance on specific aspects of data visualisation can make use of the search and navigation functions of this website.
+
+If you would prefer to read offline, you can [download the guide as a PDF](RSS-data-vis-guide.pdf). Individual sections of the guide can also be downloaded as separate PDFs using the "Other Formats \> PDF" option when shown in the right-hand navigation menu.
 
 Throughout the text you will find examples of charts and graphs. For many of these, we provide code in R to allow you to reproduce the visualisations, and we encourage you to do so and to adapt the code for your own purposes.
 


### PR DESCRIPTION
I had a couple of different issues with making the PDF that made using the `include` shortcut impossible (subdirectory image paths, and the yaml options in the different .qmd sections would overwrite anything specified in the PDF document). So I have a *slightly hacky* solution to read the file into a code block, strip out the yaml and edit the file paths, then knit what's left as a child document. 

* file name starts with an `_` so the main website project should ignore it
* Will try to get GH actions set up to make this PDF when changes are made to main
* It doesn't pull chapter titles automatically so it would need manually updated if someone added an entirely new section of the guide - but I think this is unlikely
* Will add better styling to the PDF
* Added `nul` to the gitignore file (weird file sometimes created on Windows if PDF rendering fails)