### PR TITLE
Code fold bug fix

### DIFF
--- a/docs/principles.qmd
+++ b/docs/principles.qmd
@@ -185,9 +185,6 @@ If the data displayed as x and as y are comparable, axis limits should be identi
 **Example:** The figure below illustrates that the deliberate choice of axis limits (here, y-axis limits) can make a big difference to perception, and therefore interpretation, by the reader. The only difference between the two panels is the y-axis range.
 
 ```{r}
-#| code-fold: true
-#| layout-ncol: 2
-
 library(ggplot2)
 plot_data <- data.frame(
   type = factor(
@@ -234,10 +231,6 @@ ggplot(plot_data) +
 The figure below shows data with, on average, no change compared to a reference (baseline) measurement (red horizontal line, top two panels) -- approximately half the data are below the point of no change, and the other half are above. However, this is not easily apparent from the top-left panel, which uses a linear axis, and so space is allocated asymmetrically in the vertical direction -- both up and down -- away from the reference line. In the top-right panel, which uses a logarithmic axis, the relatively even spread of the data points around the reference line is clear to see. In the bottom row, the same data are shown in histogram form, again using linear and logarithmic axes.
 
 ```{r}
-#| code-fold: true
-#| warning: false
-#| message: false
-#| layout-ncol: 2
 # Naïve plot of y vs x. If there is no change (on average),
 # half the data are below the line of no change.
 # Asymmetric view, and it depends on y/x or x/y.

--- a/docs/principles.qmd
+++ b/docs/principles.qmd
@@ -9,6 +9,7 @@ execute:
   warning: false
   eval: false
   echo: true
+editor: source
 ---
 
 Data visualisations must serve a purpose. By understanding the purpose of a visualisation, we -- as author or reader -- are in a position to assess whether a visualisation succeeds in its aims or requires improvement!
@@ -184,6 +185,7 @@ If the data displayed as x and as y are comparable, axis limits should be identi
 **Example:** The figure below illustrates that the deliberate choice of axis limits (here, y-axis limits) can make a big difference to perception, and therefore interpretation, by the reader. The only difference between the two panels is the y-axis range.
 
 ```{r}
+#| code-fold: true
 #| layout-ncol: 2
 
 library(ggplot2)
@@ -232,6 +234,7 @@ ggplot(plot_data) +
 The figure below shows data with, on average, no change compared to a reference (baseline) measurement (red horizontal line, top two panels) -- approximately half the data are below the point of no change, and the other half are above. However, this is not easily apparent from the top-left panel, which uses a linear axis, and so space is allocated asymmetrically in the vertical direction -- both up and down -- away from the reference line. In the top-right panel, which uses a logarithmic axis, the relatively even spread of the data points around the reference line is clear to see. In the bottom row, the same data are shown in histogram form, again using linear and logarithmic axes.
 
 ```{r}
+#| code-fold: true
 #| warning: false
 #| message: false
 #| layout-ncol: 2

--- a/docs/tools.qmd
+++ b/docs/tools.qmd
@@ -231,9 +231,7 @@ A work-in-progress Python package for implementing RSS colour palettes can be fo
 
 You can change the colour of chart elements in matplotlib using the `color` argument:
 
-```{{python}}
-#| message: false
-#| eval: false
+```python
 import matplotlib.pyplot as plt
 # generate data
 x_vals = ['A', 'B', 'C', 'D']
@@ -247,9 +245,7 @@ plt.show()
 
 If the colours in your plot are based on values in your data, you can also change the colours used by providing a list of colours:
 
-```{{python}}
-#| message: false
-#| eval: false
+```python
 # define colour palette
 signif_qual = ['#3fa535', '#f4c100', '#009cc4', '#f07d00']
 # create barchart
@@ -263,18 +259,14 @@ plt.show()
 
 You can change the font used in all elements of the plot using `rcParams`. Good practice when setting a custom font family is to add a generic font family (such as sans serif) as a back up. If you're using a font that isn't pre-installed on your system, you can load it in using `font_manager`:
 
-```{{python}}
-#| message: false
-#| eval: false
+```python
 from matplotlib import font_manager
 font_manager.fontManager.addfont("SourceSans3-Regular.ttf")
 ```
 
 You can specify a different font family, weight, or size using `fontdic` for individual elements.
 
-```{{python}}
-#| message: false
-#| eval: false
+```python
 # define fonts
 from matplotlib import rcParams
 rcParams['font.family'] = ['Source Sans 3', 'sans-serif']
@@ -308,9 +300,7 @@ Julia has libraries available that provide capabilities for data analysis and vi
 
 You can change the colour of chart elements in Makie using the `color` argument and custom tick labels using the `xticks` argument inside `axis`:
 
-```{{julia}}
-#| message: false
-#| eval: false
+```julia
 using CairoMakie
 # generate data
 x_vals = [1, 2, 3, 4]
@@ -323,9 +313,7 @@ barplot(x_vals, y_vals, color="#009cc4", axis=(; xticks=(1:4, ["A", "B", "C", "D
 
 If the colours in your plot are based on values in your data, you can also change the colours used by providing a list of colours:
 
-```{{julia}}
-#| message: false
-#| eval: false
+```julia
 # define colour palette
 signif_qual = ["#3fa535", "#f4c100", "#009cc4", "#f07d00"]
 # create barchart
@@ -336,9 +324,7 @@ barplot(x_vals, y_vals, color=signif_qual, axis=(; xticks=(1:4, ["A", "B", "C", 
 
 You can specify custom labels and titles using the `axis` argument:
 
-```{{julia}}
-#| message: false
-#| eval: false
+```julia
 # define labels and title
 title = "My Significance Plot"
 subtitle = "Some longer sentence explaining what is happening in the chart."
@@ -371,9 +357,7 @@ It follows the grammar of graphics and is similar to R's `ggplot2`.
 
 You can change the colour of chart elements in Makie using the `color` argument and custom tick labels using the `xticks` argument inside `axis`:
 
-```{{julia}}
-#| message: false
-#| eval: false
+```julia
 using AlgebraOfGraphics
 using CairoMakie
 # generate data
@@ -388,9 +372,7 @@ draw(plt; axis=(; xticks=(1:4, ["A", "B", "C", "D"])))
 
 If the colours in your plot are based on values in your data, you can also change the colours used by providing a list of colours:
 
-```{{julia}}
-#| message: false
-#| eval: false
+```julia
 # define colour palette
 signif_qual = ["#3fa535", "#f4c100", "#009cc4", "#f07d00"]
 # create barchart
@@ -402,9 +384,7 @@ draw(plt; axis=(; xticks=(1:4, ["A", "B", "C", "D"])))
 
 You can specify custom labels and titles using the `axis` argument:
 
-```{{julia}}
-#| message: false
-#| eval: false
+```julia
 # define labels and title
 title = "My Significance Plot"
 subtitle = "Some longer sentence explaining what is happening in the chart."


### PR DESCRIPTION
I noticed that not all of the code in the principles page was folded by default - it was caused by a weird Quarto bug. I'm not 100% sure why this problem exists but it seems adding `#| layout-ncol: 2` removes the ability to fold code... Since the code block isn't executed anyway, I've removed this option and it seems to have fixed it. 

I've also removed the double {{}} from the Python and Julia code block in tools - the code won't execute but the code fencing will be hidden, and the syntax highlighting will be applied.

Closes #46 